### PR TITLE
Using the ARGV array directly instead of join/split

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "alia",
+  "version": "0.3.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alia",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Alias To Go",
   "main": "index.js",
   "bin": {

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -1,30 +1,20 @@
 const { spawn } = require('child_process')
 const config  = require('./config')
 
+const options = {
+  stdio: 'inherit',
+  shell: true
+}
+
 module.exports = function(args) {
-  const { alias } = config.getConfig()
+  const { alias } = config.config
 
-  let cmd = args.join(' ')
-  for (const _ in args) {
-    if (alias[cmd]) {
-      const command = args.join(' ').replace(cmd, alias[cmd])
+  const cmd = args.shift()
 
-      if (command) {
-        const [ps, ...opts] = command.split(' ')
-        const task = spawn(ps, opts)
-
-        task.stdout.on('data', data => process.stdout.write(data))
-        task.stderr.on('data', data => process.stderr.write(data))
-      }
-
-      break
-    }
-
-    let t = cmd.split(' ')
-    cmd = t.slice(0, t.length - 1).join(' ')
-  }
-
-  if (!cmd) {
+  const command = alias[cmd]
+  if (command) {
+    spawn(command.shift(), command.concat(args), options)
+  } else {
     console.error(`
       No alias found for: ${args}
     `)

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,17 @@ try {
   }
 }
 
+if (!config.aliaVersion) {
+  console.log(`
+    Updating Alia config structure: ${project.version}
+  `)
+  config.aliaVersion = project.version
+  Object.keys(config.alias)
+    .filter(key => !Array.isArray(config.alias[key]))
+    .map(key => config.alias[key] = config.alias[key].split(' '))
+  writeConfig()
+}
+
 function version() {
   console.log(project.version)
 }
@@ -54,21 +65,19 @@ function help() {
   `)
 }
 
-function getConfig() {
-  return config
-}
-
 function writeConfig() {
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
 }
 
 function addAlias(args) {
-  if (!args.includes(config.options.separator)) {
+  let separatorIndex = args.indexOf(config.options.separator)
+  if (separatorIndex === -1) {
     console.error(`Invalid Input, missing separator: '${config.options.separator}'`)
     return 1
   }
 
-  const [key, cmd] = args.map(arg => arg).join(' ').split(config.options.separator).map(arg => arg.trim())
+  const key = args.slice(0, separatorIndex).join(' ')
+  const cmd = args.slice(separatorIndex + config.options.separator.length)
 
   if (config.alias[key]) {
     console.error(`Alias '${key}' already exists - remove and try again`)
@@ -78,7 +87,7 @@ function addAlias(args) {
     writeConfig()
   }
 
-  console.log(`Added alias: ${key} ${config.options.separator} ${cmd}`)
+  console.log(`Added alias: ${key} ${config.options.separator} ${cmd.join(' ')}`)
   return 0
 }
 
@@ -104,14 +113,14 @@ function removeAlias(args) {
 
 function list() {
   const alias = Object.keys(config.alias)
-    .map(key => `${key} ${config.options.separator} ${config.alias[key]}`)
+    .map(key => `${key} \t${config.options.separator} \t${config.alias[key].join(' ')}`)
     .join('\n')
 
   console.log(alias)
 }
 
 function setSeparator(args) {
-  let separator = args.join('')
+  let separator = args.join(' ')
   config.options.separator = separator
     ? separator
     : defaultConfig.options.separator
@@ -122,4 +131,4 @@ function setSeparator(args) {
 
 module.exports.alias = { addAlias, removeAlias, list, help, version }
 module.exports.options = { setSeparator }
-module.exports.getConfig = getConfig
+module.exports.config = config

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const homedir = require('os').homedir()
 
 const project = require('../package')
 const defaultConfig = require('./defaultConfig')
+defaultConfig.aliaVersion = project.version
 
 let config = defaultConfig
 
@@ -66,6 +67,7 @@ function help() {
 }
 
 function writeConfig() {
+  config.aliaVersion = project.version
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
 }
 

--- a/src/defaultConfig.json
+++ b/src/defaultConfig.json
@@ -1,5 +1,4 @@
 {
-  "aliaVersion": "0.3.0",
   "options": {
     "separator": "@"
   },

--- a/src/defaultConfig.json
+++ b/src/defaultConfig.json
@@ -1,8 +1,9 @@
 {
+  "aliaVersion": "0.3.0",
   "options": {
     "separator": "@"
   },
   "alias": {
-    "test": "echo alia is working!"
+    "test": ["echo", "alia", "is", "working!"]
   }
 }


### PR DESCRIPTION
Adding aliasVersion to config as the way the commands are stored have changed. This will trigger an update to the config file.

Commands are now added using the ARGV array itself, instead of joining it into a string. Allows for simpler command parsing with spawn.